### PR TITLE
Adjust add environment operation info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ kontent migration add --help
 
 The supported commands are divided into groups according to their target, at this first version there are just to spaces "migration" and "environment" containing following commands:
 
-* `environment add` – Creates an environment to run the migrations on.
+* `environment add` –  Store information about the environment locally.
   * The environment is defined as a named pair of values. For example, "DEV" environment can be defined as a pair of a specific project ID and Management API key. This named pair of values is stored within your local repository in a configuration file named `.environments.json`. 
   * You can specify a named pair of project ID and Management API key using these options: `--project-id <your project ID> --api-key <management api key> --name <name of the environment>`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/kontent-cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Command line interface tool that can be used for generating and running Kontent migration scripts",
   "main": "./lib/index.js",
   "types": "./lib/types/index.d.ts",

--- a/src/cmds/environment/add.ts
+++ b/src/cmds/environment/add.ts
@@ -3,7 +3,7 @@ import { saveEnvironmentConfig } from '../../utils/environmentUtils';
 
 const addEnvironmentCommand: yargs.CommandModule = {
     command: 'add',
-    describe: "Creates an environment to run the migrations on. The environment is defined as a named pair of values. For example, a 'DEV' environment can be defined as a pair of specific project ID and Management API key.",
+    describe: "Store information about the environment locally. The environment is defined as a named pair of values. For example, a 'DEV' environment can be defined as a pair of specific project ID and Management API key.",
     builder: (yargs: any) =>
         yargs
             .options({


### PR DESCRIPTION
### Motivation

Clear out that `environment add` does not creates an environment, just store the information about already created one locally

[internal link](https://app.intercom.com/a/apps/e42kus8l/inbox/inbox/conversation/19590600150032)

### Checklist

- [x] Docs have been updated (if applicable)
- [x] Adjust Help string command

### How to test

Just readme