### PR TITLE
remove rxjs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ The Kontent CLI helps you when you need to change content models within your [Ke
 
 ## Installation
 
-The Kontent CLI requires Node 10+ and npm 6+, and uses the [Kontent Management SDK](https://github.com/Kentico/kontent-management-sdk-js) to manipulate content in your projects. The SDK has a peer dependency on `rxjs`, which you need to install as well.
+The Kontent CLI requires Node 10+ and npm 6+, and uses the [Kontent Management SDK](https://github.com/Kentico/kontent-management-sdk-js) to manipulate content in your projects.
 
 ```sh
-npm install rxjs --save
 npm install -g @kentico/kontent-cli
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/kontent-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Command line interface tool that can be used for generating and running Kontent migration scripts",
   "main": "./lib/index.js",
   "types": "./lib/types/index.d.ts",


### PR DESCRIPTION
### Motivation

rxjs is no longer the peer dependency of kontent management SDK
