### PR TITLE
Upgrade management SDK version in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/kontent-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Command line interface tool that can be used for generating and running Kontent migration scripts",
   "main": "./lib/index.js",
   "types": "./lib/types/index.d.ts",
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/Kentico/kontent-cli#readme",
   "dependencies": {
-    "@kentico/kontent-backup-manager": "3.0.1",
+    "@kentico/kontent-backup-manager": "3.2.1",
     "chalk": "^4.0.0",
     "dotenv": "^8.2.0",
     "yargs": "^15.3.1"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yargs": "^15.3.1"
   },
   "peerDependencies": {
-    "@kentico/kontent-management": "^1.2.0"
+    "@kentico/kontent-management": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",


### PR DESCRIPTION
### Motivation

We are planning to add new features to the management SDK, and we need it to work with `kontent-cli`.  However, those features won't be available in the first version of the management SDK. Is it OK to upgrade `@kentico/kontent-management` package version in peer dependencies?

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
